### PR TITLE
Add SMP Notify Callback Definition

### DIFF
--- a/smp/include/smp/smp.h
+++ b/smp/include/smp/smp.h
@@ -84,6 +84,17 @@ struct smp_streamer {
  */
 int smp_process_request_packet(struct smp_streamer *streamer, void *req);
 
+#ifdef CONFIG_MCUMGR_SMP_NOTIFY_CALLBACK
+/**
+ * @brief Called whenever an SMP message is received.
+ *
+ * Called whenever an SMP message is received to notify that there is
+ * activity on the SMP server.
+ *
+ */
+extern void mcumgr_smp_notify_callback();
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This callback is used mainly by the SMP server running in the bootloader. The intent is to wait until it has been 5 seconds since the last SMP message to boot to the image, to avoid potentially jumping in the middle of uploading images.